### PR TITLE
Add initial GUI architecture for tunneling analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ESR peak analysis
 # Tunneling Junction Analyzer
 
-Estimate **barrier height** and **barrier thickness** from I–V data of metal–insulator–metal (MIM) tunneling junctions using the **Simmons** and **Brinkman–Dynes–Rowell (BDR)** models.
+Estimate **barrier height** and **barrier thickness** from I–V data of metal–insulator–metal (MIM) tunneling junctions using the
+ **Simmons** and **Brinkman–Dynes–Rowell (BDR)** models.
 
 ---
 
@@ -16,6 +17,7 @@ Estimate **barrier height** and **barrier thickness** from I–V data of metal�
 - Automatic **unit handling** (A vs mA, cm² vs m², etc.)
 - Export **fit reports**, **parameter covariance**, and **publication-ready plots**
 - CLI **and** Python API
+- Simple **Tkinter GUI** for quick interaction
 
 ---
 
@@ -27,3 +29,17 @@ python -m venv .venv && source .venv/bin/activate   # (Windows: .venv\Scripts\ac
 
 pip install -U pip
 pip install -r requirements.txt
+```
+
+---
+
+## 🖥️ Graphical Interface
+
+Launch the GUI with:
+
+```bash
+python -m esr.gui
+```
+
+Load a CSV file containing voltage and current (or current density) columns,
+select a model, and click **Fit** to estimate barrier parameters.

--- a/esr/__init__.py
+++ b/esr/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for ESR tunneling junction analysis."""
+
+__all__ = ["models", "fitting", "data", "gui"]

--- a/esr/data.py
+++ b/esr/data.py
@@ -1,0 +1,20 @@
+"""Data loading utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def load_iv_csv(path: str) -> pd.DataFrame:
+    """Load I–V or J–V data from a CSV file.
+
+    The CSV is expected to contain two columns labeled ``V`` for voltage
+    and ``I`` or ``J`` for current or current density.  Additional columns
+    are ignored but preserved in the returned :class:`~pandas.DataFrame`.
+    """
+
+    df = pd.read_csv(path)
+    return df
+
+
+__all__ = ["load_iv_csv"]

--- a/esr/fitting.py
+++ b/esr/fitting.py
@@ -1,0 +1,52 @@
+"""Fitting utilities for tunneling junction models."""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+from . import models
+
+
+def fit_model(
+    V: np.ndarray, J: np.ndarray, model: Callable[..., np.ndarray], p0: Tuple[float, ...]
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Fit a model to data using non-linear least squares.
+
+    Parameters
+    ----------
+    V, J:
+        Voltage and current density arrays.
+    model:
+        Callable returning the model current density for a voltage array
+        followed by its parameters.
+    p0:
+        Initial guess for parameters.
+
+    Returns
+    -------
+    popt, pcov:
+        Optimized parameters and covariance matrix from ``curve_fit``.
+    """
+
+    popt, pcov = curve_fit(model, V, J, p0=p0, maxfev=20000)
+    return popt, pcov
+
+
+def fit_simmons(V: np.ndarray, J: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Fit the Simmons model to data."""
+
+    p0 = (1.0, 1.0)  # barrier height (eV), thickness (nm)
+    return fit_model(V, J, models.simmons_current_density, p0)
+
+
+def fit_bdr(V: np.ndarray, J: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Fit the Brinkman–Dynes–Rowell model to data."""
+
+    p0 = (1.0, 1.0, 0.0)  # avg height, thickness, asymmetry
+    return fit_model(V, J, models.bdr_current_density, p0)
+
+
+__all__ = ["fit_simmons", "fit_bdr", "fit_model"]

--- a/esr/gui/__init__.py
+++ b/esr/gui/__init__.py
@@ -1,0 +1,5 @@
+"""Graphical interface for the tunneling junction analyzer."""
+
+from .app import main
+
+__all__ = ["main"]

--- a/esr/gui/app.py
+++ b/esr/gui/app.py
@@ -1,0 +1,135 @@
+"""Simple Tkinter-based GUI for tunneling junction analysis.
+
+This module wires together the data loading, model selection, and fitting
+utilities into a minimal graphical interface.  It is intentionally
+light‑weight, focusing on clarity over features.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+import matplotlib
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .. import data, fitting
+
+matplotlib.use("Agg")  # ensure a non-interactive backend by default
+
+
+class AnalyzerApp(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Tunneling Junction Analyzer")
+        self.geometry("800x600")
+
+        self._build_ui()
+
+        self.df = None  # loaded data
+        self.figure = plt.Figure(figsize=(5, 4))
+        self.canvas = FigureCanvasTkAgg(self.figure, master=self.plot_frame)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        """Create and place all widgets."""
+
+        toolbar = tk.Frame(self)
+        toolbar.pack(side=tk.TOP, fill=tk.X)
+
+        load_btn = tk.Button(toolbar, text="Load CSV", command=self.load_data)
+        load_btn.pack(side=tk.LEFT)
+
+        self.model_var = tk.StringVar(value="simmons")
+        model_menu = ttk.OptionMenu(
+            toolbar, self.model_var, "simmons", "simmons", "bdr"
+        )
+        model_menu.pack(side=tk.LEFT, padx=5)
+
+        fit_btn = tk.Button(toolbar, text="Fit", command=self.run_fit)
+        fit_btn.pack(side=tk.LEFT, padx=5)
+
+        self.result_var = tk.StringVar(value="No results yet")
+        result_label = tk.Label(self, textvariable=self.result_var)
+        result_label.pack(side=tk.TOP, fill=tk.X, pady=5)
+
+        self.plot_frame = tk.Frame(self)
+        self.plot_frame.pack(fill=tk.BOTH, expand=True)
+
+    # ------------------------------------------------------------------
+    def load_data(self) -> None:
+        """Load I–V data from a CSV file."""
+
+        path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
+        if not path:
+            return
+        try:
+            self.df = data.load_iv_csv(path)
+            self.result_var.set(f"Loaded {len(self.df)} rows from {path}")
+            self._plot_raw()
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror("Error", str(exc))
+
+    # ------------------------------------------------------------------
+    def _plot_raw(self) -> None:
+        if self.df is None:
+            return
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        ax.plot(self.df.iloc[:, 0], self.df.iloc[:, 1], "o", label="data")
+        ax.set_xlabel("Voltage")
+        ax.set_ylabel("Current / Current density")
+        ax.legend()
+        self.canvas.draw()
+
+    # ------------------------------------------------------------------
+    def run_fit(self) -> None:
+        """Run the selected model fit on the loaded data."""
+
+        if self.df is None:
+            messagebox.showinfo("No data", "Please load a CSV file first")
+            return
+
+        V = self.df.iloc[:, 0].to_numpy(dtype=float)
+        J = self.df.iloc[:, 1].to_numpy(dtype=float)
+
+        model_name = self.model_var.get()
+        try:
+            if model_name == "simmons":
+                params, _ = fitting.fit_simmons(V, J)
+                desc = f"Simmons fit: phi={params[0]:.3g} eV, s={params[1]:.3g} nm"
+                fitted = fitting.models.simmons_current_density(V, *params)
+            else:
+                params, _ = fitting.fit_bdr(V, J)
+                desc = (
+                    f"BDR fit: phi={params[0]:.3g} eV, s={params[1]:.3g} nm, Δϕ={params[2]:.3g} eV"
+                )
+                fitted = fitting.models.bdr_current_density(V, *params)
+
+            self.result_var.set(desc)
+            self._plot_raw()
+            ax = self.figure.axes[0]
+            ax.plot(V, fitted, label="fit")
+            ax.legend()
+            self.canvas.draw()
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror("Fit error", str(exc))
+
+
+# ----------------------------------------------------------------------------
+
+def main() -> None:
+    """Entry point for launching the GUI."""
+
+    app = AnalyzerApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/esr/models.py
+++ b/esr/models.py
@@ -1,0 +1,81 @@
+"""Physical models for tunneling junctions.
+
+This module provides current density equations for the Simmons and
+Brinkman–Dynes–Rowell (BDR) models.  These implementations are highly
+simplified; the goal is to provide a clear API rather than
+research-grade accuracy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+class CurrentDensityModel(Protocol):
+    """Protocol for models that compute current density.
+
+    Subclasses implement ``__call__`` to return the current density for a
+    given voltage array ``V`` and model parameters.  Parameters are stored
+    in dataclasses for clarity.
+    """
+
+    def __call__(self, V: np.ndarray, *params: float) -> np.ndarray:
+        """Return current density for voltage ``V``."""
+
+
+@dataclass
+class SimmonsParams:
+    """Parameters for the Simmons model."""
+
+    barrier_height: float  # eV
+    barrier_thickness: float  # nm
+
+
+def simmons_current_density(V: np.ndarray, barrier_height: float, barrier_thickness: float) -> np.ndarray:
+    """Simplified Simmons current density.
+
+    The full Simmons equation is rather involved.  For architecture
+    demonstration purposes we use a toy exponential expression that still
+    depends on the barrier height and thickness.
+    """
+
+    A = 1e5  # pre-factor (arbitrary)
+    B = 10.0  # decay constant (arbitrary)
+    effective = np.maximum(barrier_height - V / 2.0, 0)
+    return A * V * np.exp(-B * barrier_thickness * np.sqrt(effective))
+
+
+@dataclass
+class BDRParams:
+    """Parameters for the Brinkman–Dynes–Rowell model."""
+
+    avg_barrier_height: float  # eV
+    barrier_thickness: float  # nm
+    asymmetry: float  # eV
+
+
+def bdr_current_density(
+    V: np.ndarray, avg_barrier_height: float, barrier_thickness: float, asymmetry: float
+) -> np.ndarray:
+    """Simplified BDR current density.
+
+    Again we employ a simplified expression capturing the essential
+    parameter dependencies.
+    """
+
+    A = 1e5
+    B = 10.0
+    effective = np.maximum(avg_barrier_height + asymmetry * V, 0)
+    return A * V * np.exp(-B * barrier_thickness * np.sqrt(effective))
+
+
+# The names exported by this module
+__all__ = [
+    "SimmonsParams",
+    "simmons_current_density",
+    "BDRParams",
+    "bdr_current_density",
+]


### PR DESCRIPTION
## Summary
- add simplified Simmons and BDR models with fitting utilities
- implement Tkinter-based GUI to load data and run fits
- document GUI usage and add .gitignore

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0c4ddc9e88333945243cf26472ae6